### PR TITLE
[WIP] online/offline syncing loses hasMany relationship

### DIFF
--- a/lib/ember-sync/persistence.js
+++ b/lib/ember-sync/persistence.js
@@ -48,6 +48,16 @@ export default Ember.Object.extend(
         serialized = offlineSerializer.serialize(record, { includeId: true }),
         model, recordForSynchronization;
 
+    // Functionality like this will fix the test (test is WIP)
+    // var key, value, _ref;
+    // _ref = record._data;
+    // for (key in _ref) {
+    //   value = _ref[key];
+    //   if (typeof value === 'object') {
+    //     serialized[key] = value.toArray();
+    //   }
+    // }
+
     recordForSynchronization = RecordForSynchronization.create();
     recordForSynchronization.setDateObjectsInsteadOfDateString(record, serialized);
 

--- a/tests/integration/ember-sync-test.js
+++ b/tests/integration/ember-sync-test.js
@@ -201,10 +201,19 @@ test("#find - searches offline/online simultaneously, syncing online into offlin
 });
 
 test("#find - searches offline/online simultaneously, syncing online into offline (with hasMany relationships) and returning a stream of data", function() {
-  inventoryItem = onlineStore.createRecord('inventoryItem', { id: 1, name: "Fender" });
-  cartItem = onlineStore.createRecord('cartItem', { id: 1, price: "12" });
-  inventoryItem.get('cartItems').pushObject(cartItem);
-  equal(inventoryItem.get('cartItems.length'), 1, "inventory has 1 cart item");
+  fixture = JSON.stringify({
+    inventoryItem: {
+      records: { // this schema is how LSAdapter works
+        1: { id: 1, name: "Fender", cartItems:[1] }
+      }
+    },
+    cartItem: {
+      records: {
+        1: { id: 1, price: 12 }
+      }
+    }
+  });
+  localStorage.setItem('onlineStore', fixture);
 
   stop();
 


### PR DESCRIPTION
Related issue: https://github.com/kurko/ember-sync/issues/15#issuecomment-48251695.

Can't get to meaningful error messages yet, it stalls with:

> Error: Assertion Failed: You looked up the 'cartItems' relationship on '<(subclass of DS.Model):ember311:1>' but some of the associated records were not loaded. Either make sure they are all loaded together with the parent record, or specify that the relationship is async (`DS.hasMany({ async: true })`)